### PR TITLE
Specify package files in 'dependencies' of MLHUB.yaml

### DIFF
--- a/MLHUB.yaml
+++ b/MLHUB.yaml
@@ -24,6 +24,14 @@ dependencies :
     - tidyr
     - rattle
     - rpart.plot
+  files:
+    - demo.R
+    - display.R
+    - print.R
+    - rain_rpart_model.RData
+    - README.md
+    - score.R
+    - train.R
 commands:
   demo   : Run the model and present performance metrics.
   print  : View a textual representation of the model.


### PR DESCRIPTION
Package file specification is now available at mlhubber/mlhub@f21a442